### PR TITLE
Unify font styling for book listings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -368,7 +368,7 @@ body {
     border-radius: 12px;
     background-color: #f4f4f4;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    font-family: 'et-book', serif;
+    font-family: "Literata", Arial, Helvetica, sans-serif;
     font-size: 18px;
     color: #333;
     text-align: left;
@@ -438,7 +438,7 @@ body {
     background-color: #fff;
     padding: 12px 16px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    font-family: 'et-book', serif;
+    font-family: "Literata", Arial, Helvetica, sans-serif;
     transition: background-color 0.3s ease;
     cursor: pointer;
 }
@@ -539,7 +539,7 @@ body {
     padding: 8px 12px;
     background-color: #fff;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    font-family: 'et-book', serif;
+    font-family: "Literata", Arial, Helvetica, sans-serif;
 }
 
 .book-card:hover {


### PR DESCRIPTION
## Summary
- use Literata font for `.books-display`, `.horizontal-card`, and `.book-card`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a448425b08329bdb91c4143b80936