### PR TITLE
Add modal form for card actions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -433,6 +433,7 @@ body {
     display: flex;
     justify-content: space-between;
     align-items: left;
+    position: relative;
     border: 1px solid #333;
     border-radius: 8px;
     background-color: #fff;
@@ -556,4 +557,46 @@ body {
 
 .pagination button {
     padding: 4px 8px;
+}
+
+.add-icon {
+    position: absolute;
+    bottom: 4px;
+    right: 4px;
+    width: 18px;
+    height: 18px;
+    border: 1px solid #333;
+    border-radius: 50%;
+    background: #fff;
+    color: #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.modal-overlay.active {
+    display: flex;
+}
+
+.modal-content {
+    background: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    width: 300px;
 }

--- a/index.html
+++ b/index.html
@@ -117,6 +117,27 @@
         </div>
     </div>
 
+    <div id="formModal" class="modal-overlay hidden">
+        <div class="modal-content">
+            <form id="cardForm">
+                <label>
+                    Number:
+                    <input type="text" id="cardNumber" readonly />
+                </label>
+                <label>
+                    Name:
+                    <input type="text" id="dummyName" />
+                </label>
+                <label>
+                    Description:
+                    <textarea id="dummyDesc"></textarea>
+                </label>
+                <button type="submit">Submit</button>
+                <button type="button" id="modalClose">Close</button>
+            </form>
+        </div>
+    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
     <script defer src="js/sidebar.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,35 @@ let currentBooks = [];
 let currentPage = 1;
 let currentCardId = '';
 
+const formModal = document.getElementById('formModal');
+const cardNumberInput = document.getElementById('cardNumber');
+const cardForm = document.getElementById('cardForm');
+const modalCloseBtn = document.getElementById('modalClose');
+
+function openFormModal(id) {
+    cardNumberInput.value = id;
+    formModal.classList.add('active');
+    formModal.classList.remove('hidden');
+}
+
+function closeFormModal() {
+    formModal.classList.remove('active');
+    formModal.classList.add('hidden');
+}
+
+cardForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    closeFormModal();
+    alert('Dummy form submitted');
+});
+
+modalCloseBtn.addEventListener('click', closeFormModal);
+formModal.addEventListener('click', (e) => {
+    if (e.target === formModal) {
+        closeFormModal();
+    }
+});
+
 function getRandomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
@@ -179,9 +208,15 @@ function createCard(data, row) {
       <div class="top">${data.id}</div>
       <div class="category" lang="en">${insertSoftHyphens(data.node_label)}</div>
       <div class="count">${bookCount}</div>
+      <div class="add-icon">+</div>
     `;
 
     card.innerHTML = innerHtml;
+    const addIcon = card.querySelector('.add-icon');
+    addIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openFormModal(data.id);
+    });
 
     // Add click handler to manage selection
     card.addEventListener('click', async () => {
@@ -299,9 +334,15 @@ function createLeafCard(data, row) {
     <div class="card-right">
       <div class="card-meta">${bookCount}</div>
     </div>
+    <div class="add-icon">+</div>
     `;
 
     card.innerHTML = innerHtml;
+    const addIcon = card.querySelector('.add-icon');
+    addIcon.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openFormModal(data.id);
+    });
 
     // Add click handler to manage selection
     card.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- allow opening a form from each card using a new `+` icon
- style modal overlay and add-icon
- show the card number in the dummy form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aee6f7fac8329a4494c2dd7e3d50d