### PR TITLE
Enhance book list cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -541,11 +541,27 @@ body {
     background-color: #fff;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     font-family: "Literata", Arial, Helvetica, sans-serif;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
 }
 
 .book-card:hover {
     background-color: #f0f0f0;
     padding-left: 20px;
+}
+
+.book-title {
+    font-weight: bold;
+    font-size: 16px;
+    margin-bottom: 4px;
+}
+
+.book-author,
+.book-classification,
+.book-year {
+    font-size: 14px;
+    color: #555;
 }
 
 .pagination {

--- a/js/main.js
+++ b/js/main.js
@@ -70,10 +70,23 @@ function generateRandomBooks(count) {
         'Ancient Astronomy of India',
         'Myths of the Himalayas'
     ];
+    const authors = [
+        'A. Sharma',
+        'B. Gupta',
+        'C. Iyer',
+        'D. Singh',
+        'E. Banerjee',
+        'F. Reddy',
+        'G. Pillai',
+        'H. Varma'
+    ];
     const books = [];
     for (let i = 0; i < count; i++) {
         const title = `${titles[i % titles.length]} ${Math.floor(i / titles.length) + 1}`;
-        books.push(title);
+        const author = authors[i % authors.length];
+        const classification = `CLS-${getRandomInt(100, 999)}.${getRandomInt(0, 9)}`;
+        const year = 1950 + (i % 70);
+        books.push({ title, author, classification, year });
     }
     return books;
 }
@@ -84,7 +97,13 @@ function renderBooks() {
     const totalPages = Math.max(1, Math.ceil(totalBooks / booksPerPage));
     const start = (currentPage - 1) * booksPerPage;
     const visible = currentBooks.slice(start, start + booksPerPage);
-    const listHtml = visible.map(b => `<li class="book-card">${b}</li>`).join('');
+    const listHtml = visible.map(b => `
+        <li class="book-card">
+            <div class="book-title">${b.title}</div>
+            <div class="book-author">Author: ${b.author}</div>
+            <div class="book-classification">Classification: ${b.classification}</div>
+            <div class="book-year">Year: ${b.year}</div>
+        </li>`).join('');
 
     displayBox.innerHTML = `📚 Books in selected category (<strong>${currentCardId}</strong>) : <span class="book-count">${totalBooks}</span>` +
         `<ul class="book-list">${listHtml}</ul>` +


### PR DESCRIPTION
## Summary
- render book list entries as cards
- generate dummy book details (author, classification, year)
- update styles for the new book card fields

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685af06ad31883299497af1612dccfde