### PR TITLE
Display real books and modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,13 @@
         </div>
     </div>
 
+    <div id="bookModal" class="modal-overlay hidden">
+        <div class="modal-content">
+            <div id="bookModalBody"></div>
+            <button type="button" id="bookModalClose">Close</button>
+        </div>
+    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
     <script defer src="js/sidebar.js"></script>


### PR DESCRIPTION
## Summary
- query Supabase for book data instead of generating dummies
- add modal overlay to show book details
- fetch books with pagination when a classification card is clicked

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685afa1a3d688329b70e24822a9db08f