### PR TITLE
Improve modals with new styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -612,23 +612,46 @@ body {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    display: none;
+    display: flex;
     align-items: center;
     justify-content: center;
     z-index: 2000;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 
 .modal-overlay.active {
-    display: flex;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
 }
 
 .modal-content {
+    position: relative;
     background: #ffffff;
-    padding: 20px;
+    padding: 20px 20px 16px 20px;
     border-radius: 8px;
     width: 300px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
     font-family: "Literata", Arial, Helvetica, sans-serif;
+}
+
+.modal-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    line-height: 1;
+    color: #666;
+    cursor: pointer;
+}
+
+.modal-close:hover {
+    color: #333;
 }
 
 /* Book modal specific styling */

--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
 
     <div id="formModal" class="modal-overlay hidden">
         <div class="modal-content">
+            <button type="button" class="modal-close" id="modalClose">&times;</button>
             <form id="cardForm">
                 <label>
                     Number:
@@ -133,15 +134,14 @@
                     <textarea id="dummyDesc"></textarea>
                 </label>
                 <button type="submit">Submit</button>
-                <button type="button" id="modalClose">Close</button>
             </form>
         </div>
     </div>
 
     <div id="bookModal" class="modal-overlay hidden">
         <div class="modal-content">
+            <button type="button" class="modal-close" id="bookModalClose">&times;</button>
             <div id="bookModalBody"></div>
-            <button type="button" id="bookModalClose">Close</button>
         </div>
     </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -22,13 +22,15 @@ const modalCloseBtn = document.getElementById('modalClose');
 
 function openFormModal(id) {
     cardNumberInput.value = id;
-    formModal.classList.add('active');
     formModal.classList.remove('hidden');
+    requestAnimationFrame(() => {
+        formModal.classList.add('active');
+    });
 }
 
 function closeFormModal() {
     formModal.classList.remove('active');
-    formModal.classList.add('hidden');
+    setTimeout(() => formModal.classList.add('hidden'), 300);
 }
 
 cardForm.addEventListener('submit', (e) => {
@@ -89,13 +91,15 @@ function openBookModal(book) {
         .join('');
 
     bookModalBody.innerHTML = `<div class="book-details-grid">${html}</div>`;
-    bookModal.classList.add('active');
     bookModal.classList.remove('hidden');
+    requestAnimationFrame(() => {
+        bookModal.classList.add('active');
+    });
 }
 
 function closeBookModal() {
     bookModal.classList.remove('active');
-    bookModal.classList.add('hidden');
+    setTimeout(() => bookModal.classList.add('hidden'), 300);
 }
 
 bookModalClose.addEventListener('click', closeBookModal);


### PR DESCRIPTION
## Summary
- add fade-in/out to modals
- add close icons for both modals
- tweak open/close JS logic for transitions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685affa991a88329928d479c787bdc5c