### PR TITLE
Update book card layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -534,6 +534,7 @@ body {
     gap: 8px;
 }
 
+
 .book-card {
     border: 1px solid #333;
     border-radius: 6px;
@@ -542,35 +543,48 @@ body {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     font-family: "Literata", Arial, Helvetica, sans-serif;
     display: flex;
+    flex-direction: row;
+    min-height: 80px;
+    cursor: pointer;
+}
+
+.book-card-left {
+    background-color: #f8d7da;
+    color: #8b0000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    min-width: 70px;
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.book-card-right {
+    flex: 1;
+    padding: 8px 12px;
+    display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 4px;
 }
 
 .book-card-header {
-    background-color: #8b0000;
-    color: #fff;
     font-weight: bold;
-    padding: 4px 8px;
-    font-size: 16px;
-}
-
-.book-card-content {
-    padding: 8px 12px;
+    font-size: 18px;
 }
 
 .book-card:hover {
     background-color: #f0f0f0;
-    padding-left: 20px;
+    padding-left: 0;
 }
 
 .book-title {
     font-weight: bold;
     font-size: 16px;
-    margin-bottom: 4px;
 }
 
 .book-author,
-.book-classification,
+.book-pages,
 .book-year {
     font-size: 14px;
     color: #555;

--- a/js/main.js
+++ b/js/main.js
@@ -114,10 +114,11 @@ function renderBooks() {
     const totalPages = Math.max(1, Math.ceil(currentTotalBooks / booksPerPage));
     const listHtml = currentBooks.map((b, i) => `
         <li class="book-card" data-index="${i}">
-            <div class="book-card-header">${b.title || b.book_title || b.name || 'Untitled'}</div>
-            <div class="book-card-content">
-                ${b.author || b.authors || b.primary_author ? `<div class="book-author">Author: ${b.author || b.authors || b.primary_author}</div>` : ''}
-                ${b.classification_number ? `<div class="book-classification">Classification: ${b.classification_number}</div>` : ''}
+            <div class="book-card-left">${b.classification_number || ''}</div>
+            <div class="book-card-right">
+                <div class="book-card-header">${b.title || b.book_title || b.name || 'Untitled'}</div>
+                ${b.author || b.authors || b.primary_author ? `<div class="book-author">Main author: ${b.author || b.authors || b.primary_author}</div>` : ''}
+                ${b.pages || b.page_count ? `<div class="book-pages">Pages: ${b.pages || b.page_count}</div>` : ''}
                 ${b.year || b.publication_year ? `<div class="book-year">Year: ${b.year || b.publication_year}</div>` : ''}
             </div>
         </li>`).join('');


### PR DESCRIPTION
## Summary
- redesign book card display
- show classification number in separate left column
- add author, pages and year to the right side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b010b7460832996fcb7810f6eb8a9