### PR TITLE
Fix prefix search for spaced classification numbers

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -29,11 +29,13 @@ async function getBookCount(prefix) {
     if (bookCountCache[prefix] !== undefined) {
         return bookCountCache[prefix];
     }
+    // Replace spaces with dashes as classification numbers are stored using '-'
+    const sanitizedPrefix = prefix.replace(/\s+/g, '-');
     try {
         const { count, error } = await supabase
             .from('committed_records')
             .select('*', { count: 'exact', head: true })
-            .like('classification_number', `${prefix}%`);
+            .like('classification_number', `${sanitizedPrefix}%`);
         if (error) {
             console.error('Error fetching book count:', error);
             bookCountCache[prefix] = 0;

--- a/js/main.js
+++ b/js/main.js
@@ -49,11 +49,13 @@ formModal.addEventListener('click', (e) => {
 async function fetchBooks(prefix, page = 1) {
     const from = (page - 1) * booksPerPage;
     const to = from + booksPerPage - 1;
+    // Classification numbers store spaces as '-' so normalise before querying
+    const sanitizedPrefix = prefix.replace(/\s+/g, '-');
     try {
         const { data, error } = await supabase
             .from('committed_records')
             .select('*')
-            .like('classification_number', `${prefix}%`)
+            .like('classification_number', `${sanitizedPrefix}%`)
             .range(from, to);
         if (error) {
             console.error('Error fetching books:', error);


### PR DESCRIPTION
## Summary
- normalize classification number prefixes before lookups

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b6a3a76408329814fc3e22baf4ef3