### PR TITLE
Improve classification search precision

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -31,11 +31,14 @@ async function getBookCount(prefix) {
     }
     // Replace spaces with dashes as classification numbers are stored using '-'
     const sanitizedPrefix = prefix.replace(/\s+/g, '-');
+    const likePattern = /[A-Za-z\s]/.test(prefix)
+        ? `${sanitizedPrefix}%`
+        : sanitizedPrefix;
     try {
         const { count, error } = await supabase
             .from('committed_records')
             .select('*', { count: 'exact', head: true })
-            .like('classification_number', `${sanitizedPrefix}%`);
+            .like('classification_number', likePattern);
         if (error) {
             console.error('Error fetching book count:', error);
             bookCountCache[prefix] = 0;

--- a/js/main.js
+++ b/js/main.js
@@ -51,11 +51,14 @@ async function fetchBooks(prefix, page = 1) {
     const to = from + booksPerPage - 1;
     // Classification numbers store spaces as '-' so normalise before querying
     const sanitizedPrefix = prefix.replace(/\s+/g, '-');
+    const likePattern = /[A-Za-z\s]/.test(prefix)
+        ? `${sanitizedPrefix}%`
+        : sanitizedPrefix;
     try {
         const { data, error } = await supabase
             .from('committed_records')
             .select('*')
-            .like('classification_number', `${sanitizedPrefix}%`)
+            .like('classification_number', likePattern)
             .range(from, to);
         if (error) {
             console.error('Error fetching books:', error);


### PR DESCRIPTION
## Summary
- refine getBookCount and fetchBooks to handle classification numbers with and without trailing letters

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685b6da4ef98832992df9b83811bc1e1