### PR TITLE
Improve leaf node card layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -432,7 +432,7 @@ body {
 .horizontal-card {
     display: flex;
     justify-content: space-between;
-    align-items: left;
+    align-items: center;
     position: relative;
     border: 1px solid #333;
     border-radius: 8px;
@@ -457,8 +457,10 @@ body {
 .card-left {
     display: flex;
     flex-direction: row;
-    align-items: left;
+    align-items: center;
     gap: 3px;
+    flex-shrink: 0;
+    margin-right: 6px;
 }
 
 .card-center {
@@ -466,6 +468,8 @@ body {
     flex-direction: row;
     align-items: center;
     gap: 3px;
+    flex: 1;
+    overflow: hidden;
 }
 
 .card-title {
@@ -479,16 +483,18 @@ body {
     color: #555;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    word-break: break-word;
     hyphens: auto;
 }
 
 .card-right {
     display: flex;
     flex-direction: row;
-    align-items: right;
-    gap: 3px;
+    align-items: center;
+    gap: 4px;
     font-size: 14px;
     color: #777;
+    flex-shrink: 0;
 }
 
 .horizontal-card.selected .card-left,
@@ -617,6 +623,13 @@ body {
     cursor: pointer;
     font-weight: bold;
     font-size: 14px;
+}
+
+.horizontal-card .add-icon {
+    position: static;
+    bottom: auto;
+    right: auto;
+    margin-left: 4px;
 }
 
 .modal-overlay {

--- a/js/main.js
+++ b/js/main.js
@@ -389,8 +389,8 @@ function createLeafCard(data, row) {
     </div>
     <div class="card-right">
       <div class="card-meta">${bookCount}</div>
+      <div class="add-icon">+</div>
     </div>
-    <div class="add-icon">+</div>
     `;
 
     card.innerHTML = innerHtml;


### PR DESCRIPTION
## Summary
- adjust `createLeafCard` markup so the add icon sits with the book count
- tweak horizontal card flexbox rules
- ensure text wraps cleanly and keep add icon aligned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b702b4f108329ab050be71e58fdb4