### PR TITLE
Add authors and language fields to book card

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -591,7 +591,8 @@ body {
 
 .book-author,
 .book-pages,
-.book-year {
+.book-year,
+.book-language {
     font-size: 14px;
     color: #555;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -120,6 +120,9 @@ function renderBooks() {
             <div class="book-card-right">
                 <div class="book-card-header">${b.title || b.book_title || b.name || 'Untitled'}</div>
                 ${b.author || b.authors || b.primary_author ? `<div class="book-author">Main author: ${b.author || b.authors || b.primary_author}</div>` : ''}
+                ${b.first_author && b.first_author !== 'null' ? `<div class="book-author">First author: ${b.first_author}</div>` : ''}
+                ${b.second_author && b.second_author !== 'null' ? `<div class="book-author">Second author: ${b.second_author}</div>` : ''}
+                ${b.language && b.language !== 'null' ? `<div class="book-language">Language: ${b.language}</div>` : ''}
                 ${b.pages || b.page_count ? `<div class="book-pages">Pages: ${b.pages || b.page_count}</div>` : ''}
                 ${b.year || b.publication_year ? `<div class="book-year">Year: ${b.year || b.publication_year}</div>` : ''}
             </div>


### PR DESCRIPTION
## Summary
- show first and second authors and language in each book card
- style `.book-language` similar to other book metadata

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b715db6588329bb71d2f4d0eadc5e