### PR TITLE
Add React-based entry form modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -722,3 +722,50 @@ body {
 #bookModalClose:hover {
     background-color: #a00;
 }
+.react-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 12px;
+    font-family: "Literata", Arial, Helvetica, sans-serif;
+}
+
+.react-form .form-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.react-form .form-group label {
+    font-size: 14px;
+    margin-bottom: 2px;
+}
+
+.react-form input,
+.react-form textarea {
+    padding: 4px 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.react-form textarea {
+    resize: vertical;
+}
+
+.react-form .form-actions {
+    grid-column: 1 / -1;
+    text-align: right;
+    margin-top: 8px;
+}
+
+.react-form button {
+    padding: 6px 12px;
+    background-color: #003B5C;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.react-form button:disabled {
+    background-color: #777;
+}

--- a/index.html
+++ b/index.html
@@ -120,21 +120,7 @@
     <div id="formModal" class="modal-overlay hidden">
         <div class="modal-content">
             <button type="button" class="modal-close" id="modalClose">&times;</button>
-            <form id="cardForm">
-                <label>
-                    Number:
-                    <input type="text" id="cardNumber" readonly />
-                </label>
-                <label>
-                    Name:
-                    <input type="text" id="dummyName" />
-                </label>
-                <label>
-                    Description:
-                    <textarea id="dummyDesc"></textarea>
-                </label>
-                <button type="submit">Submit</button>
-            </form>
+            <div id="reactFormRoot"></div>
         </div>
     </div>
 
@@ -147,8 +133,11 @@
 
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
     <script defer src="js/sidebar.js"></script>
     <script defer src="js/data.js"></script>
+    <script defer src="js/reactForm.js"></script>
     <script defer src="js/main.js"></script>
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -16,12 +16,12 @@ let currentCardId = '';
 let currentTotalBooks = 0;
 
 const formModal = document.getElementById('formModal');
-const cardNumberInput = document.getElementById('cardNumber');
-const cardForm = document.getElementById('cardForm');
 const modalCloseBtn = document.getElementById('modalClose');
 
 function openFormModal(id) {
-    cardNumberInput.value = id;
+    if (window.renderForm) {
+        window.renderForm(id);
+    }
     formModal.classList.remove('hidden');
     requestAnimationFrame(() => {
         formModal.classList.add('active');
@@ -33,11 +33,6 @@ function closeFormModal() {
     setTimeout(() => formModal.classList.add('hidden'), 300);
 }
 
-cardForm.addEventListener('submit', (e) => {
-    e.preventDefault();
-    closeFormModal();
-    alert('Dummy form submitted');
-});
 
 modalCloseBtn.addEventListener('click', closeFormModal);
 formModal.addEventListener('click', (e) => {

--- a/js/reactForm.js
+++ b/js/reactForm.js
@@ -1,0 +1,141 @@
+// React form component for adding staging entries
+(function () {
+    const { useState } = React;
+
+    function FormField({ label, name, value, onChange, type = 'text', readOnly = false, required = false }) {
+        return React.createElement('div', { className: 'form-group' }, [
+            React.createElement('label', { key: 'label' }, label + (required ? ' *' : '')),
+            type === 'textarea'
+                ? React.createElement('textarea', { key: 'input', name, value, onChange, readOnly, required })
+                : React.createElement('input', { key: 'input', type, name, value, onChange, readOnly, required })
+        ]);
+    }
+
+    function CardForm({ classificationNumber, onClose }) {
+        const [formData, setFormData] = useState({
+            subject: '',
+            item_number: '',
+            title: '',
+            subtitle: '',
+            title_with_author: '',
+            title_indian_language: '',
+            subtitle_indian_language: '',
+            main_author: '',
+            second_author: '',
+            third_author: '',
+            statement_of_responsibility: '',
+            edition: '',
+            publisher: '',
+            year_of_publication: '',
+            pages: '',
+            volume: '',
+            language: '',
+            language_note: '',
+            general_note: '',
+            toc: '',
+            accession_number: '',
+            series_note: '',
+            cataloguer: '',
+            libraries: ''
+        });
+        const [submitting, setSubmitting] = useState(false);
+
+        const handleChange = (e) => {
+            const { name, value } = e.target;
+            setFormData((prev) => ({ ...prev, [name]: value }));
+        };
+
+        const handleSubmit = async (e) => {
+            e.preventDefault();
+            if (!formData.item_number) {
+                alert('Item Number is required');
+                return;
+            }
+            setSubmitting(true);
+            const id = (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15));
+            const payload = {
+                id,
+                classification_number: classificationNumber,
+                item_number: formData.item_number,
+                subject: formData.subject || null,
+                title: formData.title || null,
+                subtitle: formData.subtitle || null,
+                title_with_author: formData.title_with_author || null,
+                title_indian_language: formData.title_indian_language || null,
+                subtitle_indian_language: formData.subtitle_indian_language || null,
+                main_author: formData.main_author || null,
+                second_author: formData.second_author || null,
+                third_author: formData.third_author || null,
+                statement_of_responsibility: formData.statement_of_responsibility || null,
+                edition: formData.edition || null,
+                publisher: formData.publisher || null,
+                year_of_publication: formData.year_of_publication ? parseInt(formData.year_of_publication, 10) : null,
+                pages: formData.pages ? parseInt(formData.pages, 10) : null,
+                volume: formData.volume || null,
+                language: formData.language || null,
+                language_note: formData.language_note || null,
+                general_note: formData.general_note || null,
+                toc: formData.toc || null,
+                accession_number: formData.accession_number || null,
+                series_note: formData.series_note || null,
+                cataloguer: formData.cataloguer || null,
+                libraries: formData.libraries || null,
+                status: 'pending'
+            };
+            try {
+                const { error } = await supabase.from('staging_entries').insert(payload);
+                if (error) {
+                    console.error('Error inserting:', error);
+                    alert('Error submitting form');
+                } else {
+                    alert('Entry submitted successfully');
+                    if (onClose) onClose();
+                }
+            } catch (err) {
+                console.error(err);
+                alert('Error submitting form');
+            }
+            setSubmitting(false);
+        };
+
+        return React.createElement('form', { className: 'react-form', onSubmit: handleSubmit }, [
+            FormField({ label: 'Classification Number', name: 'classification_number', value: classificationNumber, onChange: () => {}, readOnly: true }),
+            FormField({ label: 'Item Number', name: 'item_number', value: formData.item_number, onChange: handleChange, required: true }),
+            FormField({ label: 'Subject', name: 'subject', value: formData.subject, onChange: handleChange }),
+            FormField({ label: 'Title', name: 'title', value: formData.title, onChange: handleChange }),
+            FormField({ label: 'Subtitle', name: 'subtitle', value: formData.subtitle, onChange: handleChange }),
+            FormField({ label: 'Title With Author', name: 'title_with_author', value: formData.title_with_author, onChange: handleChange }),
+            FormField({ label: 'Title Indian Language', name: 'title_indian_language', value: formData.title_indian_language, onChange: handleChange }),
+            FormField({ label: 'Subtitle Indian Language', name: 'subtitle_indian_language', value: formData.subtitle_indian_language, onChange: handleChange }),
+            FormField({ label: 'Main Author', name: 'main_author', value: formData.main_author, onChange: handleChange }),
+            FormField({ label: 'Second Author', name: 'second_author', value: formData.second_author, onChange: handleChange }),
+            FormField({ label: 'Third Author', name: 'third_author', value: formData.third_author, onChange: handleChange }),
+            FormField({ label: 'Statement Of Responsibility', name: 'statement_of_responsibility', value: formData.statement_of_responsibility, onChange: handleChange }),
+            FormField({ label: 'Edition', name: 'edition', value: formData.edition, onChange: handleChange }),
+            FormField({ label: 'Publisher', name: 'publisher', value: formData.publisher, onChange: handleChange }),
+            FormField({ label: 'Year Of Publication', name: 'year_of_publication', value: formData.year_of_publication, onChange: handleChange, type: 'number' }),
+            FormField({ label: 'Pages', name: 'pages', value: formData.pages, onChange: handleChange, type: 'number' }),
+            FormField({ label: 'Volume', name: 'volume', value: formData.volume, onChange: handleChange }),
+            FormField({ label: 'Language', name: 'language', value: formData.language, onChange: handleChange }),
+            FormField({ label: 'Language Note', name: 'language_note', value: formData.language_note, onChange: handleChange }),
+            FormField({ label: 'General Note', name: 'general_note', value: formData.general_note, onChange: handleChange }),
+            FormField({ label: 'Toc', name: 'toc', value: formData.toc, onChange: handleChange, type: 'textarea' }),
+            FormField({ label: 'Accession Number', name: 'accession_number', value: formData.accession_number, onChange: handleChange }),
+            FormField({ label: 'Series Note', name: 'series_note', value: formData.series_note, onChange: handleChange }),
+            FormField({ label: 'Cataloguer', name: 'cataloguer', value: formData.cataloguer, onChange: handleChange }),
+            FormField({ label: 'Libraries', name: 'libraries', value: formData.libraries, onChange: handleChange }),
+            React.createElement('div', { className: 'form-actions' }, [
+                React.createElement('button', { type: 'submit', disabled: submitting }, submitting ? 'Submitting...' : 'Submit')
+            ])
+        ]);
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('reactFormRoot'));
+
+    window.renderForm = function (classificationNumber) {
+        root.render(React.createElement(CardForm, {
+            classificationNumber,
+            onClose: window.closeFormModal
+        }));
+    };
+})();


### PR DESCRIPTION
## Summary
- switch form modal to use React
- add script tags for React libraries and new component
- style new React form
- adapt card modal opening logic

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_685cd558d7988329b618478538eab6bc