### PR TITLE
Improve subject path and modal styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -752,8 +752,12 @@ body {
     flex-direction: column;
 }
 
+.modal-content {
+    font-size: 16px;
+}
+
 .react-form .form-group label {
-    font-size: 28px;
+    font-size: 0.75em;
     margin-bottom: 4px;
 }
 
@@ -763,7 +767,8 @@ body {
     padding: 8px 10px;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 28px;
+    font-size: 0.75em;
+    box-sizing: border-box;
 }
 
 .react-form textarea {
@@ -783,7 +788,7 @@ body {
     border: none;
     border-radius: 4px;
     cursor: pointer;
-    font-size: 28px;
+    font-size: 0.75em;
 }
 
 .react-form button:disabled {

--- a/js/data.js
+++ b/js/data.js
@@ -23,30 +23,35 @@ window.getClassificationPath = function (code) {
     const entry = map[code];
     if (!entry) return code;
     const segments = [];
+    // Top level
     if (entry.top_level_node) {
         const top = map[entry.top_level_node];
-        if (top) segments.push(`${entry.top_level_node} ${top.entry_name}`);
+        segments.push(`${entry.top_level_node} ${top ? top.entry_name : ''}`);
     }
     let prefix = entry.top_level_node;
+    // First level
     if (entry.first_level_node != null) {
-        prefix += `.${entry.first_level_node}`;
+        prefix = `${prefix}.${entry.first_level_node}`;
         const first = map[prefix];
-        segments.push(`${entry.first_level_node} ${first ? first.entry_name : ''}`);
+        segments.push(`${prefix} ${first ? first.entry_name : ''}`);
     }
+    // Second level
     if (entry.second_level_node != null) {
-        prefix += entry.second_level_node;
+        prefix = `${prefix}${entry.second_level_node}`;
         const second = map[prefix];
-        segments.push(`${entry.second_level_node} ${second ? second.entry_name : ''}`);
+        segments.push(`${prefix} ${second ? second.entry_name : ''}`);
     }
+    // Third level
     if (entry.third_level_node != null) {
-        prefix += entry.third_level_node;
+        prefix = `${prefix}${entry.third_level_node}`;
         const third = map[prefix];
-        segments.push(`${entry.third_level_node} ${third ? third.entry_name : ''}`);
+        segments.push(`${prefix} ${third ? third.entry_name : ''}`);
     }
+    // Fourth level
     if (entry.fourth_level_node != null) {
-        prefix += entry.fourth_level_node;
+        prefix = `${prefix}${entry.fourth_level_node}`;
         const fourth = map[prefix];
-        segments.push(`${entry.fourth_level_node} ${fourth ? fourth.entry_name : ''}`);
+        segments.push(`${prefix} ${fourth ? fourth.entry_name : ''}`);
     }
     return segments.join(' / ');
 };


### PR DESCRIPTION
## Summary
- compute full classification path using card codes in `getClassificationPath`
- shrink modal form font and ensure fields fit without overflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5e43ff0c8329bd4e002d81ee2a3e