### PR TITLE
Improve barren node display detection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -43,12 +43,12 @@ formModal.addEventListener('click', (e) => {
 
 function isLeafType(type) {
     if (!type) return false;
-    return String(type).toLowerCase() === 'leaf';
+    return String(type).toLowerCase().trim().includes('leaf');
 }
 
 function isBarrenType(type) {
     if (!type) return false;
-    return String(type).toLowerCase() === 'barren';
+    return String(type).toLowerCase().trim().includes('barren');
 }
 
 async function fetchBooks(prefix, page = 1) {


### PR DESCRIPTION
## Summary
- detect `leaf` and `barren` node types using substring match rather than exact equality

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d729167088329b1f426481d83ad84