### PR TITLE
Fix barren node subject path and hyphenation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -193,8 +193,9 @@ function displayBooksForCard(card) {
 
 
 function insertSoftHyphens(text) {
-    // Add soft hyphens after logical break points (like capital letters or compound parts)
-    return text.replace(/([a-zāīūṛṅñṭḍṇśṣ]+)/gi, '$1&shy;');
+    // Insert a soft hyphen after every character so that
+    // a hyphen is displayed if the word wraps to the next line.
+    return text.replace(/([^\s])/g, '$1&shy;');
 }
 
 


### PR DESCRIPTION
## Summary
- handle codes with suffixes in `getClassificationPath`
- append node label with `#` for final segment
- insert soft hyphens after every character so wrapped words show a hyphen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d87449b848329a415439eb09c9a2f