### PR TITLE
Adjust barren card width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -431,10 +431,14 @@ body {
 
 .barren-card-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(95px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(123.5px, 1fr));
     gap: 4px;
     padding: 8px;
     background-color: #ddd;
+}
+
+#barren-row .card {
+    width: clamp(104px, 9.75vw, 123.5px);
 }
 
 .horizontal-card {


### PR DESCRIPTION
## Summary
- enlarge the grid column and card widths for barren nodes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d89cc59508329bb06b909c6a07933