### PR TITLE
Fix barren row width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -430,11 +430,12 @@ body {
 }
 
 .barren-card-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(95px, 1fr));
+    display: flex;
+    flex-wrap: nowrap;
     gap: 4px;
     padding: 8px;
     background-color: #ddd;
+    width: max-content;
 }
 
 .horizontal-card {


### PR DESCRIPTION
## Summary
- keep `barren-card-container` flex based and use `max-content` width to prevent it from stretching wider than other rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d91f673848329835b266ee4fab674