### PR TITLE
Improve word hyphenation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -127,7 +127,8 @@ body {
     font-weight: bold;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    hyphens: auto;
+    /* rely only on manual soft hyphens */
+    hyphens: manual;
 }
 
 .card .count {
@@ -492,7 +493,8 @@ body {
     word-wrap: break-word;
     overflow-wrap: break-word;
     word-break: break-word;
-    hyphens: auto;
+    /* rely only on manual soft hyphens */
+    hyphens: manual;
 }
 
 .card-right {

--- a/js/main.js
+++ b/js/main.js
@@ -185,9 +185,26 @@ function displayBooksForCard(card) {
 
 
 function insertSoftHyphens(text) {
-    // Insert a soft hyphen after every character so that
-    // a hyphen is displayed if the word wraps to the next line.
-    return text.replace(/([^\s])/g, '$1&shy;');
+    const noHyphen = ['studies', 'puranas', 'purana', 'history'];
+    const custom = {
+        'Mahabharata': 'Maha&shy;bha&shy;ra&shy;ta',
+        'Ramayana': 'Ra&shy;ma&shy;ya&shy;na',
+        'Bhagavad': 'Bha&shy;ga&shy;vad',
+        'Gita': 'Gi&shy;ta',
+        'Karnataka': 'Kar&shy;na&shy;ta&shy;ka',
+        'Tamil': 'Ta&shy;mil',
+        'Telangana': 'Te&shy;lan&shy;ga&shy;na',
+        'Andhra': 'An&shy;dhra',
+        'Pradesh': 'Pra&shy;desh'
+    };
+    return text.split(/(\s+)/).map(part => {
+        const word = part.trim();
+        if (!word) return part;
+        const lower = word.toLowerCase();
+        if (noHyphen.includes(lower)) return part;
+        if (custom[word]) return custom[word];
+        return word.replace(/([aeiou])([bcdfghjklmnpqrstvwxyz])/gi, '$1&shy;$2');
+    }).join('');
 }
 
 


### PR DESCRIPTION
## Summary
- avoid CSS auto hyphenation so words only break at soft hints
- add JS function to intelligently insert soft hyphens

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_685f761cdfdc832984d5ad22f7ac66f2