### PR TITLE
Enhance hyphenation and card layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -43,7 +43,7 @@ body {
 
 .card {
     flex: 0 0 auto;
-    width: clamp(80px, 7.5vw, 95px);
+    width: clamp(80px, 7.5vw, 114px);
     /* fluid width with limits */
     /* height: 130px; */
     border-radius: 4px;
@@ -182,6 +182,12 @@ body {
     width: 100%;
     overflow-x: auto;
     /* This is the scrollable layer */
+}
+
+.down-arrow {
+    text-align: center;
+    font-size: 18px;
+    margin: 4px 0;
 }
 
 .scroll-column {
@@ -425,14 +431,14 @@ body {
 
 .horizontal-card-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(216px, 1fr));
     gap: 12px;
     align-items: stretch;
 }
 
 .barren-card-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(95px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(114px, 1fr));
     gap: 4px;
     padding: 8px;
     background-color: #ddd;

--- a/index.html
+++ b/index.html
@@ -87,27 +87,35 @@
                 <div class="scroll-row">
                     <div class="card-container" id="first-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="second-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="third-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="fourth-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="fifth-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="sixth-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="seventh-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="barren-card-container" id="barren-row"></div>
                 </div>
+                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-column">
                     <div class="horizontal-card-container" id="leaf-row"></div>
                 </div>

--- a/js/main.js
+++ b/js/main.js
@@ -184,6 +184,26 @@ function displayBooksForCard(card) {
 }
 
 
+function hyphenateDevanagari(word) {
+    const vowels = /[\u0904-\u0914\u0960-\u0961\u0972-\u0977]/;
+    const matras = /[\u093E-\u094C\u0962-\u0963]/;
+    const consonants = /[\u0915-\u0939\u0958-\u095F\u0978-\u097F]/;
+    const virama = '\u094D';
+    let result = '';
+    for (let i = 0; i < word.length; i++) {
+        const ch = word[i];
+        result += ch;
+        if (i < word.length - 1) {
+            const next = word[i + 1];
+            if (ch === virama) continue;
+            if (matras.test(ch) || vowels.test(ch) || (consonants.test(ch) && next !== virama)) {
+                result += '&shy;';
+            }
+        }
+    }
+    return result;
+}
+
 function insertSoftHyphens(text) {
     const noHyphen = ['studies', 'puranas', 'purana', 'history'];
     const custom = {
@@ -203,7 +223,10 @@ function insertSoftHyphens(text) {
         const lower = word.toLowerCase();
         if (noHyphen.includes(lower)) return part;
         if (custom[word]) return custom[word];
-        return word.replace(/([aeiou])([bcdfghjklmnpqrstvwxyz])/gi, '$1&shy;$2');
+        if (/[^\u0000-\u007f]/.test(word) && /[\u0900-\u097F]/.test(word)) {
+            return hyphenateDevanagari(word);
+        }
+        return word.replace(/([aeiouāīūṛṝḷḹeou])([bcdfghjklmnpqrstvwxyz])/gi, '$1&shy;$2');
     }).join('');
 }
 


### PR DESCRIPTION
## Summary
- improve soft hyphen logic with Devanagari support
- widen card widths and card containers
- show arrows between card levels for clarity

## Testing
- `node -c js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6860daa45c808329b6a797f464cd4e38