### PR TITLE
Remove down arrows and adjust layout sizing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -43,7 +43,7 @@ body {
 
 .card {
     flex: 0 0 auto;
-    width: clamp(80px, 7.5vw, 114px);
+    width: clamp(60px, 6vw, 100px);
     /* fluid width with limits */
     /* height: 130px; */
     border-radius: 4px;
@@ -185,9 +185,7 @@ body {
 }
 
 .down-arrow {
-    text-align: center;
-    font-size: 18px;
-    margin: 4px 0;
+    display: none;
 }
 
 .scroll-column {
@@ -254,7 +252,7 @@ body {
     flex-grow: 1;
     overflow-x: auto;
     padding: 20px;
-    max-width: calc(100vw - 260px);
+    max-width: calc(100vw - 312px);
     /* subtract sidebar width + padding */
 
 }
@@ -431,7 +429,7 @@ body {
 
 .horizontal-card-container {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(216px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     gap: 12px;
     align-items: stretch;
 }

--- a/index.html
+++ b/index.html
@@ -87,35 +87,27 @@
                 <div class="scroll-row">
                     <div class="card-container" id="first-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="second-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="third-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="fourth-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="fifth-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="sixth-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="card-container" id="seventh-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-row">
                     <div class="barren-card-container" id="barren-row"></div>
                 </div>
-                <div class="down-arrow">&#8595;</div>
                 <div class="scroll-column">
                     <div class="horizontal-card-container" id="leaf-row"></div>
                 </div>


### PR DESCRIPTION
## Summary
- remove down arrow elements between card rows
- hide `.down-arrow` styling
- make default card width smaller
- reduce main container width
- narrow horizontal card grid

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860dcf42b0c83299c15e6b33dc51769