### PR TITLE
Fix hyphenation for non-English words

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -125,8 +125,8 @@ body {
 .card .category {
     padding: 6px;
     font-weight: bold;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+    overflow-wrap: normal;
+    word-break: normal;
     /* rely only on manual soft hyphens */
     hyphens: manual;
 }
@@ -494,9 +494,8 @@ body {
 .card-subtitle {
     font-size: 14px;
     color: #555;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    word-break: break-word;
+    overflow-wrap: normal;
+    word-break: normal;
     /* rely only on manual soft hyphens */
     hyphens: manual;
 }
@@ -728,7 +727,8 @@ body {
 
 .book-details-grid .field-value {
     text-align: left;
-    word-break: break-word;
+    word-break: normal;
+    overflow-wrap: normal;
 }
 
 #bookModalClose {

--- a/js/main.js
+++ b/js/main.js
@@ -223,10 +223,11 @@ function insertSoftHyphens(text) {
         const lower = word.toLowerCase();
         if (noHyphen.includes(lower)) return part;
         if (custom[word]) return custom[word];
-        if (/[^\u0000-\u007f]/.test(word) && /[\u0900-\u097F]/.test(word)) {
-            return hyphenateDevanagari(word);
+        // Only hyphenate Latin words
+        if (/^[A-Za-z]+$/.test(word)) {
+            return word.replace(/([aeiouāīūṛṝḷḹeou])([bcdfghjklmnpqrstvwxyz])/gi, '$1&shy;$2');
         }
-        return word.replace(/([aeiouāīūṛṝḷḹeou])([bcdfghjklmnpqrstvwxyz])/gi, '$1&shy;$2');
+        return part;
     }).join('');
 }
 


### PR DESCRIPTION
## Summary
- stop breaking non‑English text
- only add soft hyphens for Latin words

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861163275ec832993b5368065057e26