### PR TITLE
Improve card layout alignment

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -26,10 +26,11 @@ body {
     scrollbar-width: thin;
     justify-content: flex-start;
     scroll-behavior: smooth;
-    width: max-content;
+    width: 100%;
+    max-width: 900px;
+    min-width: 600px;
     align-items: stretch;
-
-
+    margin: 0 auto;
 }
 
 .card-container::-webkit-scrollbar {
@@ -43,7 +44,7 @@ body {
 
 .card {
     flex: 0 0 auto;
-    width: clamp(60px, 6vw, 100px);
+    width: clamp(80px, 10vw, 140px);
     /* fluid width with limits */
     /* height: 130px; */
     border-radius: 4px;
@@ -119,11 +120,11 @@ body {
     background-color: #de1717ef;
     color: white;
     font-weight: bold;
-    padding: 2px 0;
+    padding: 1px 0;
 }
 
 .card .category {
-    padding: 6px;
+    padding: 4px;
     font-weight: bold;
     overflow-wrap: normal;
     word-break: normal;
@@ -174,7 +175,7 @@ body {
     /* space between rows */
     padding: 1px;
     /* center rows horizontally */
-    align-items: flex-start;
+    align-items: center;
     width: 100%;
 }
 
@@ -254,7 +255,9 @@ body {
     padding: 20px;
     max-width: calc(100vw - 312px);
     /* subtract sidebar width + padding */
-
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 #first-row .card .top {

--- a/index.html
+++ b/index.html
@@ -80,9 +80,6 @@
                 <img src="assets/logo1.png" alt="Centered Image" />
             </div>
             <div class="wrapper">
-                <div class="logo-container">
-
-                </div>
                 <div id="loader" class="loader hidden"></div>
                 <div class="scroll-row">
                     <div class="card-container" id="first-row"></div>


### PR DESCRIPTION
## Summary
- center-align the main content and card rows
- widen card containers and make them responsive
- enlarge cards and tighten their padding
- clean up empty logo container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68616d30da088329a6f006ccb59f5314