### PR TITLE
Add hyphenation toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -878,3 +878,45 @@ body {
     border: 1px solid green;
     border-radius: 3px;
 }
+
+/* Settings floating button and modal */
+#settings-icon {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    background-color: #565555;
+    color: #fff;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    z-index: 1000;
+}
+
+#settings-modal {
+    position: fixed;
+    bottom: 70px;
+    right: 20px;
+    background-color: #fff;
+    border: 1px solid #333;
+    border-radius: 8px;
+    padding: 10px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+}
+
+#settings-modal.hidden {
+    display: none;
+}
+
+body.no-hyphenation .card .category,
+body.no-hyphenation .card-subtitle {
+    overflow-wrap: normal;
+    word-break: normal;
+    hyphens: none;
+    white-space: nowrap;
+}
+

--- a/index.html
+++ b/index.html
@@ -122,6 +122,14 @@
         </div>
     </div>
 
+    <div id="settings-icon">⚙️</div>
+    <div id="settings-modal" class="hidden">
+        <label>
+            Hyphenation
+            <input type="checkbox" id="hyphenation-toggle" checked>
+        </label>
+    </div>
+
     <div id="formModal" class="modal-overlay hidden">
         <div class="modal-content">
             <button type="button" class="modal-close" id="modalClose">&times;</button>


### PR DESCRIPTION
## Summary
- add floating settings button with toggle for hyphenation
- implement hyphenation toggle logic in main.js
- store original labels and adjust card width when hyphenation is off
- style settings popup and disable hyphenation CSS rules

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686202aceb6c83299419b26ee3b4ffb9