### PR TITLE
Add dark mode setting and refine hyphenation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -43,9 +43,10 @@ body {
 }
 
 .card {
-    flex: 0 0 calc(12% - 6px);
-    width: clamp(120px, calc(12% - 6px), 200px);
-    /* default width fits 10 cards per row */
+    flex: 0 0 103.164px;
+    width: 103.164px;
+    min-width: 103.164px;
+    max-width: 103.164px;
     /* height: 130px; */
     border-radius: 4px;
     border: 1px solid #333;
@@ -906,6 +907,9 @@ body {
     padding: 10px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 }
 
 #settings-modal.hidden {
@@ -917,6 +921,74 @@ body.no-hyphenation .card-subtitle {
     overflow-wrap: normal;
     word-break: normal;
     hyphens: none;
-    white-space: nowrap;
+    white-space: normal;
+}
+
+.setting-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 20px;
+}
+
+.switch input {
+    display: none;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: 0.4s;
+    border-radius: 20px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 16px;
+    width: 16px;
+    left: 2px;
+    bottom: 2px;
+    background-color: white;
+    transition: 0.4s;
+    border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+    background-color: #2196F3;
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(20px);
+}
+
+body.dark-mode {
+    background-color: #1a1a1a;
+    color: #eee;
+}
+
+body.dark-mode .sidebar {
+    background-color: #333;
+    color: #fff;
+}
+
+body.dark-mode .books-display {
+    background-color: #444;
+    color: #eee;
+}
+
+body.dark-mode #settings-icon {
+    background-color: #333;
 }
 

--- a/index.html
+++ b/index.html
@@ -124,10 +124,20 @@
 
     <div id="settings-icon">⚙️</div>
     <div id="settings-modal" class="hidden">
-        <label>
-            Hyphenation
-            <input type="checkbox" id="hyphenation-toggle" checked>
-        </label>
+        <div class="setting-item">
+            <span>Hyphenation</span>
+            <label class="switch">
+                <input type="checkbox" id="hyphenation-toggle" checked>
+                <span class="slider"></span>
+            </label>
+        </div>
+        <div class="setting-item">
+            <span>Dark Mode</span>
+            <label class="switch">
+                <input type="checkbox" id="dark-mode-toggle">
+                <span class="slider"></span>
+            </label>
+        </div>
     </div>
 
     <div id="formModal" class="modal-overlay hidden">

--- a/js/main.js
+++ b/js/main.js
@@ -244,21 +244,6 @@ function insertSoftHyphens(text) {
     }).join('');
 }
 
-function adjustCardWidth(card) {
-    const labelEl = card.querySelector('.category') || card.querySelector('.card-subtitle');
-    if (!labelEl) return;
-    const temp = document.createElement('span');
-    temp.style.visibility = 'hidden';
-    temp.style.whiteSpace = 'nowrap';
-    temp.style.fontSize = window.getComputedStyle(labelEl).fontSize;
-    temp.style.fontFamily = window.getComputedStyle(labelEl).fontFamily;
-    temp.textContent = labelEl.textContent;
-    document.body.appendChild(temp);
-    const width = temp.getBoundingClientRect().width + 20;
-    document.body.removeChild(temp);
-    card.style.flex = '0 0 auto';
-    card.style.width = width + 'px';
-}
 
 function updateCardHyphenation(card) {
     const labelEl = card.querySelector('.category') || card.querySelector('.card-subtitle');
@@ -266,11 +251,8 @@ function updateCardHyphenation(card) {
     if (!labelEl || !original) return;
     if (hyphenationEnabled) {
         labelEl.innerHTML = insertSoftHyphens(original);
-        card.style.flex = '';
-        card.style.width = '';
     } else {
         labelEl.textContent = original;
-        adjustCardWidth(card);
     }
 }
 
@@ -369,7 +351,6 @@ function createCard(data, row) {
     `;
 
     card.innerHTML = innerHtml;
-    if (!hyphenationEnabled) adjustCardWidth(card);
     // Fetch actual count asynchronously and update when received
     getBookCount(data.id).then(count => {
         card.setAttribute('data-total-books', count);
@@ -559,7 +540,6 @@ function createLeafCard(data, row) {
     `;
 
     card.innerHTML = innerHtml;
-    if (!hyphenationEnabled) adjustCardWidth(card);
     // Fetch count asynchronously
     getBookCount(data.id).then(count => {
         card.setAttribute('data-total-books', count);
@@ -890,6 +870,7 @@ suggestionsBox.addEventListener('click', async (e) => {
 const settingsIcon = document.getElementById('settings-icon');
 const settingsModal = document.getElementById('settings-modal');
 const hyphenToggle = document.getElementById('hyphenation-toggle');
+const darkToggle = document.getElementById('dark-mode-toggle');
 
 settingsIcon.addEventListener('click', () => {
     settingsModal.classList.toggle('hidden');
@@ -900,4 +881,13 @@ hyphenToggle.addEventListener('change', () => {
     updateHyphenation();
 });
 
-document.addEventListener('DOMContentLoaded', updateHyphenation);
+darkToggle.addEventListener('change', () => {
+    document.body.classList.toggle('dark-mode', darkToggle.checked);
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    updateHyphenation();
+    if (darkToggle.checked) {
+        document.body.classList.add('dark-mode');
+    }
+});


### PR DESCRIPTION
## Summary
- refactor card width so all cards share a fixed width
- stop stretching cards when hyphenation is disabled
- allow non-hyphenated text to wrap normally
- add stylish toggle switches for settings
- introduce dark mode toggle

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862051739788329af14e5443208ce0c