### PR TITLE
Fix sidebar layout and floating menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -16,6 +16,10 @@ body {
     align-items: center;
     justify-content: space-between;
     box-sizing: border-box;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
 }
 
 .topbar-title {
@@ -187,8 +191,9 @@ body {
     width: 100%;
     gap: 1px;
     min-height: 100vh;
-    padding: 40px;
+    padding: 0;
     box-sizing: border-box;
+    margin-top: 60px;
 }
 
 
@@ -224,8 +229,8 @@ body {
     width: 170px;
     flex-shrink: 0;
     background-color: #565555;
-    border-radius: 20px 0 0 20px;
-    margin: 16px;
+    border-radius: 0;
+    margin: 0;
     padding: 16px;
     display: flex;
     flex-direction: column;
@@ -234,6 +239,7 @@ body {
     transition: width 0.3s ease;
     position: relative;
     font-size: 14px;
+    min-height: 100vh;
 }
 
 
@@ -277,7 +283,7 @@ body {
     flex-grow: 1;
     overflow-x: auto;
     padding: 20px;
-    max-width: calc(100vw - 282px);
+    max-width: calc(100vw - 170px);
     /* subtract sidebar width + padding */
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- make the top menu bar fixed so it floats while scrolling
- remove sidebar rounding and margins
- extend sidebar height to the full viewport
- adjust page layout padding and main content width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68621638eff48329b534f917eba4e36b