### PR TITLE
Add visual cue after search

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -577,6 +577,19 @@ body {
     }
 }
 
+@keyframes popHighlight {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.05);
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
 .book-list {
     margin-top: 10px;
     padding: 0;
@@ -598,6 +611,7 @@ body {
     flex-direction: row;
     min-height: 80px;
     cursor: pointer;
+    transition: transform 0.3s ease;
 }
 
 .book-card-left {
@@ -628,6 +642,10 @@ body {
 .book-card:hover {
     background-color: #f0f0f0;
     padding-left: 0;
+}
+
+.book-card.pop-animate {
+    animation: popHighlight 0.6s ease-in-out;
 }
 
 .book-title {

--- a/js/main.js
+++ b/js/main.js
@@ -887,6 +887,15 @@ suggestionsBox.addEventListener('click', async (e) => {
         const bookSection = document.getElementById('books-display');
         if (bookSection) {
             bookSection.scrollIntoView({ behavior: 'smooth' });
+            setTimeout(() => {
+                const card = bookSection.querySelector('.book-card');
+                if (card) {
+                    card.classList.add('pop-animate');
+                    card.addEventListener('animationend', () => {
+                        card.classList.remove('pop-animate');
+                    }, { once: true });
+                }
+            }, 600);
         }
     }
 });


### PR DESCRIPTION
## Summary
- add popHighlight animation for book cards
- trigger the animation after scrolling to the book list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68623e58d2e88329bb8579297ea320a0