### PR TITLE
Extend pop-out effect

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -580,13 +580,16 @@ body {
 @keyframes popHighlight {
     0% {
         transform: scale(1);
+        background-color: #fff;
     }
     50% {
         transform: scale(1.05);
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+        background-color: #ffcccc;
     }
     100% {
         transform: scale(1);
+        background-color: #fff;
     }
 }
 
@@ -611,7 +614,7 @@ body {
     flex-direction: row;
     min-height: 80px;
     cursor: pointer;
-    transition: transform 0.3s ease;
+    transition: transform 0.9s ease;
 }
 
 .book-card-left {
@@ -645,7 +648,7 @@ body {
 }
 
 .book-card.pop-animate {
-    animation: popHighlight 0.6s ease-in-out;
+    animation: popHighlight 0.9s ease-in-out;
 }
 
 .book-title {


### PR DESCRIPTION
## Summary
- make the book card pop-out animation last 0.9s
- flash a light red background during the animation

## Testing
- `bash -lc 'ls -1'`

------
https://chatgpt.com/codex/tasks/task_e_68623f5339348329a13c082358d62fa5