### PR TITLE
Fix top bar overlap and improve modal text fields

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,17 +8,17 @@ body {
 }
 
 .topbar {
-    width: 100%;
+    width: calc(100% - 182px);
     background-color: #f8d7da;
     color: #000000;
     padding: 8px 16px;
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-end;
     box-sizing: border-box;
     position: fixed;
     top: 0;
-    left: 0;
+    left: 182px;
     z-index: 1000;
 }
 
@@ -288,16 +288,16 @@ body {
     padding: 20px;
     margin-top: 60px;
     margin-left: 182px;
-    max-width: calc(100vw - 182px);
-    /* subtract sidebar width + padding */
+    width: calc(100vw - 182px);
     display: flex;
     flex-direction: column;
     align-items: center;
+    box-sizing: border-box;
 }
 
 .sidebar.collapsed + .main-content {
     margin-left: 60px;
-    max-width: calc(100vw - 60px);
+    width: calc(100vw - 60px);
 }
 
 #first-row .card .top {
@@ -790,8 +790,11 @@ body {
 
 .book-details-grid .field-value {
     text-align: left;
-    word-break: normal;
-    overflow-wrap: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+    max-height: 4.5em;
+    overflow-y: auto;
 }
 
 #bookModalClose {
@@ -852,6 +855,7 @@ body {
 
 .react-form textarea {
     resize: vertical;
+    min-height: 4.5em;
 }
 
 .react-form .form-actions {

--- a/index.html
+++ b/index.html
@@ -12,14 +12,13 @@
 
 <body>
     <nav class="topbar">
-        <span class="topbar-title">CPS Classification of Indian Knowledge</span>
         <img src="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/icons/person-circle.svg" class="user-icon" alt="User" />
     </nav>
     <div class="page-layout">
         <div id="sidebar" class="sidebar expanded">
             <div class="sidebar-top">
                 <img src="assets/logo.png" alt="Center for Policy Logo" class="logo" />
-                <span class="title">Classification of Indian Knowldge Systems</span>
+                <span class="title">CPS Classification of Indian Knowledge</span>
                 <button class="toggle-btn" onclick="toggleSidebar()">«</button>
             </div>
 

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -4,4 +4,15 @@ function toggleSidebar() {
 
     const toggleBtn = sidebar.querySelector(".toggle-btn");
     toggleBtn.textContent = sidebar.classList.contains("collapsed") ? "»" : "«";
+
+    const topbar = document.querySelector('.topbar');
+    if (topbar) {
+        if (sidebar.classList.contains('collapsed')) {
+            topbar.style.left = '60px';
+            topbar.style.width = 'calc(100% - 60px)';
+        } else {
+            topbar.style.left = '182px';
+            topbar.style.width = 'calc(100% - 182px)';
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- keep sidebar title short
- hide heading in menu bar
- make menu bar align to sidebar
- center content region and update for sidebar width
- wrap long fields in book detail modal
- enlarge textarea fields for editing
- update toggleSidebar to resize menu bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686248de7b6c8329a78fa91868f93ab4