### PR TITLE
Refactor main layout and align leaf row

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -196,6 +196,20 @@ body {
     margin-top: 0;
 }
 
+.content-container {
+    margin-top: 60px;
+    margin-left: 182px;
+    width: calc(100vw - 182px);
+    display: flex;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
+.sidebar.collapsed + .content-container {
+    margin-left: 60px;
+    width: calc(100vw - 60px);
+}
+
 
 .wrapper {
     display: flex;
@@ -286,18 +300,11 @@ body {
     flex-grow: 1;
     overflow-x: auto;
     padding: 20px;
-    margin-top: 60px;
-    margin-left: 182px;
-    width: calc(100vw - 182px);
+    width: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
     box-sizing: border-box;
-}
-
-.sidebar.collapsed + .main-content {
-    margin-left: 60px;
-    width: calc(100vw - 60px);
 }
 
 #first-row .card .top {
@@ -475,6 +482,9 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
     gap: 12px;
     align-items: stretch;
+    max-width: 1200px;
+    min-width: 800px;
+    margin: 0 auto;
 }
 
 .barren-card-container {
@@ -483,6 +493,9 @@ body {
     gap: 4px;
     padding: 8px;
     background-color: #ddd;
+    max-width: 1200px;
+    min-width: 800px;
+    margin: 0 auto;
 }
 
 .horizontal-card {

--- a/index.html
+++ b/index.html
@@ -78,7 +78,8 @@
         </div>
 
 
-        <div class="main-content">
+        <div class="content-container">
+            <div class="main-content">
             <div class="logo-container">
                 <img src="assets/logo1.png" alt="Centered Image" />
             </div>
@@ -123,6 +124,7 @@
                 </div>
             </div>
         </div>
+    </div>
     </div>
 
     <div id="settings-icon">⚙️</div>


### PR DESCRIPTION
## Summary
- add `.content-container` to hold `main-content`
- center main content and adjust sidebar overlap
- align `horizontal-card-container` and `barren-card-container` with card rows

## Testing
- `echo 'No tests'`

------
https://chatgpt.com/codex/tasks/task_e_68624b281d10832990faa3a07c8b34cd