### PR TITLE
Improve topbar and sidebar appearance

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -9,12 +9,13 @@ body {
 
 .topbar {
     width: calc(100% - 182px);
-    background-color: #f8d7da;
-    color: #000000;
+    background-color: #333;
+    color: #ffffff;
     padding: 8px 16px;
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    gap: 16px;
     box-sizing: border-box;
     position: fixed;
     top: 0;
@@ -27,10 +28,26 @@ body {
     font-weight: bold;
 }
 
+.menu-link {
+    color: #ffffff;
+    text-decoration: none;
+    margin-right: 8px;
+}
+
+.menu-link:hover {
+    text-decoration: underline;
+}
+
+.username {
+    color: #ffffff;
+    font-weight: bold;
+}
+
 .user-icon {
     width: 24px;
     height: 24px;
     border-radius: 50%;
+    filter: invert(1);
 }
 
 .logo {
@@ -50,7 +67,7 @@ body {
     gap: 4px;
     padding: 0px;
     scrollbar-width: thin;
-    justify-content: flex-start;
+    justify-content: center;
     scroll-behavior: smooth;
     width: 100%;
     max-width: 1200px;
@@ -242,13 +259,14 @@ body {
 .sidebar {
     width: 182px;
     flex-shrink: 0;
-    background-color: #f8d7da;
+    background-color: #333;
     border-radius: 0;
     padding: 16px;
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    color: black;
+    color: #ffffff;
+    text-align: justify;
     transition: width 0.3s ease;
     position: fixed;
     top: 0;
@@ -289,7 +307,7 @@ body {
 
 .toggle-btn {
     background: none;
-    color: black;
+    color: #ffffff;
     border: none;
     cursor: pointer;
     font-size: 18px;
@@ -362,13 +380,13 @@ body {
     display: flex;
     align-items: center;
     gap: 6px;
-    color: #000;
+    color: #ffffff;
     text-decoration: none;
     font-size: 14px;
 }
 
 .github-link:hover {
-    color: #333;
+    color: #cccccc;
 }
 
 .github-icon {
@@ -383,7 +401,7 @@ body {
     align-items: center;
     justify-content: center;
     gap: 6px;
-    color: #000;
+    color: #ffffff;
     text-decoration: none;
     font-size: 14px;
     margin-top: 10px;
@@ -391,6 +409,15 @@ body {
 
 .whatsapp-link:hover {
     color: #25D366;
+}
+
+.catalogue-link {
+    color: #ffffff;
+    text-decoration: none;
+}
+
+.catalogue-link:hover {
+    text-decoration: underline;
 }
 
 .whatsapp-icon {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
 
 <body>
     <nav class="topbar">
+        <a href="index.html" class="menu-link">Home</a>
+        <a href="approvals.html" class="menu-link">Approvals</a>
+        <a href="dashboard.html" class="menu-link">Dashboard</a>
         <img src="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/icons/person-circle.svg" class="user-icon" alt="User" />
+        <span class="username">Admin-CPS</span>
     </nav>
     <div class="page-layout">
         <div id="sidebar" class="sidebar expanded">
@@ -42,14 +46,12 @@
                 <hr class="sidebar-divider">
 
                 <div class="sidebar-middle">
-                    <a href="https://bookish-archive-nexus.lovable.app/search" class="catalogue-link"
-                        style="color: black;">Search The
+                    <a href="https://bookish-archive-nexus.lovable.app/search" class="catalogue-link">Search The
                         Catalogue</a>
                 </div>
 
                 <div class="sidebar-middle">
-                    <a href="https://bookish-archive-nexus.lovable.app" class="catalogue-link"
-                        style="color: black;">Cataloguing Tool</a>
+                    <a href="https://bookish-archive-nexus.lovable.app" class="catalogue-link">Cataloguing Tool</a>
                 </div>
             </div>
 
@@ -132,7 +134,7 @@
         <div class="setting-item">
             <span>Hyphenation</span>
             <label class="switch">
-                <input type="checkbox" id="hyphenation-toggle" checked>
+                <input type="checkbox" id="hyphenation-toggle">
                 <span class="slider"></span>
             </label>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -22,7 +22,7 @@ let currentTotalBooks = 0;
 const searchCache = {};
 let booksCache = {};
 
-let hyphenationEnabled = true;
+let hyphenationEnabled = false;
 
 const formModal = document.getElementById('formModal');
 const modalCloseBtn = document.getElementById('modalClose');


### PR DESCRIPTION
## Summary
- style the topbar and sidebar with dark grey background and white text
- center cards within each container
- set default hyphenation off
- add simple menu links with a username display

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68636cad36e083298b079c7bfa84aa22