### PR TITLE
Add admin approval workflow

### DIFF
--- a/approvals.html
+++ b/approvals.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Approvals</title>
+    <link href="https://fonts.googleapis.com/css2?family=Literata&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+    <nav class="topbar">
+        <a href="index.html" class="menu-link">Home</a>
+        <a href="approvals.html" class="menu-link">Approvals</a>
+        <a href="dashboard.html" class="menu-link">Dashboard</a>
+        <img src="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/icons/person-circle.svg" class="user-icon" alt="User" />
+        <span class="username">Admin-CPS</span>
+    </nav>
+    <div class="approvals-wrapper">
+        <div class="approvals-list-pane">
+            <label for="status-filter" class="filter-label">Filter</label>
+            <select id="status-filter" multiple size="3">
+                <option value="pending" selected>Pending</option>
+                <option value="approved">Approved</option>
+                <option value="rejected">Rejected</option>
+            </select>
+            <ul id="submission-list" role="listbox" class="submission-list"></ul>
+        </div>
+        <div class="approvals-detail-pane">
+            <div id="record-form" class="record-form"></div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
+    <script src="js/data.js"></script>
+    <script src="js/approvals.js"></script>
+</body>
+</html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1108,3 +1108,126 @@ body.dark-mode #settings-icon {
     background-color: #333;
 }
 
+
+/* Approvals page styles */
+.approvals-wrapper {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+    width: 100%;
+    padding: 80px 16px 16px 16px;
+    box-sizing: border-box;
+    min-height: 100vh;
+}
+
+.approvals-list-pane {
+    flex-basis: 30%;
+    max-width: 320px;
+    min-width: 220px;
+    border-right: 1px solid #ccc;
+    display: flex;
+    flex-direction: column;
+}
+
+.filter-label {
+    font-size: 0.85em;
+    margin-bottom: 4px;
+}
+
+#status-filter {
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+.submission-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.approvals-detail-pane {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 8px;
+}
+
+.approvals-list-item {
+    padding: 8px 4px;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+
+.approvals-list-item:focus {
+    outline: 2px solid #003B5C;
+    outline-offset: -2px;
+}
+
+.approvals-list-item.selected {
+    background-color: #eef;
+}
+
+.status-badge {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    text-transform: capitalize;
+}
+
+.status-badge.pending { background-color: #f0ad4e; color: #000; }
+.status-badge.approved { background-color: #5cb85c; color: #fff; }
+.status-badge.rejected { background-color: #d9534f; color: #fff; }
+
+.approval-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    font-family: "Literata", Arial, Helvetica, sans-serif;
+}
+
+.approval-form textarea {
+    width: 100%;
+    min-height: 3em;
+}
+
+.approval-form .current-value {
+    font-size: 0.75em;
+    color: #555;
+    margin-bottom: 2px;
+}
+
+.approval-form .changed textarea {
+    border-color: #f0ad4e;
+}
+
+.action-buttons {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.action-buttons button {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    color: #fff;
+}
+
+.action-buttons .approve-btn { background-color: #5cb85c; }
+.action-buttons .reject-btn { background-color: #d9534f; }
+
+@media (max-width: 640px) {
+    .approvals-wrapper {
+        flex-direction: column;
+    }
+    .approvals-list-pane {
+        max-width: none;
+        min-width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #ccc;
+    }
+}
+

--- a/js/approvals.js
+++ b/js/approvals.js
@@ -1,0 +1,155 @@
+const statusFilter = document.getElementById('status-filter');
+const listEl = document.getElementById('submission-list');
+const formContainer = document.getElementById('record-form');
+
+let stagingRecords = [];
+let selectedId = null;
+
+async function loadRecords() {
+    try {
+        const { data, error } = await supabase
+            .from('staging_entries')
+            .select('*');
+        if (error) {
+            console.error('Error loading records', error);
+            return;
+        }
+        stagingRecords = data || [];
+        applyFilter();
+    } catch (err) {
+        console.error('Unexpected error loading records', err);
+    }
+}
+
+function applyFilter() {
+    const statuses = Array.from(statusFilter.selectedOptions).map(o => o.value);
+    const filtered = stagingRecords.filter(r => statuses.includes(r.status));
+    renderList(filtered);
+}
+
+function renderList(records) {
+    listEl.innerHTML = '';
+    records.forEach(rec => {
+        const li = document.createElement('li');
+        li.className = 'approvals-list-item';
+        li.tabIndex = 0;
+        li.setAttribute('role', 'option');
+        li.setAttribute('data-id', rec.id);
+        li.setAttribute('aria-selected', rec.id === selectedId ? 'true' : 'false');
+        if (rec.id === selectedId) li.classList.add('selected');
+        const created = new Date(rec.created_at).toLocaleDateString();
+        li.innerHTML = `<div style="display:flex; justify-content:space-between; font-size:0.9em;">
+            <span>${rec.classification_number || ''}</span>
+            <span>${created}</span>
+        </div>
+        <div>${rec.title || ''}</div>
+        <div style="text-align:right;">
+            <span class="status-badge ${rec.status}">${rec.status}</span>
+        </div>`;
+        li.addEventListener('click', () => selectRecord(rec.id));
+        li.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectRecord(rec.id); } });
+        listEl.appendChild(li);
+    });
+}
+
+async function selectRecord(id) {
+    selectedId = id;
+    applyFilter();
+    const record = stagingRecords.find(r => r.id === id);
+    if (!record) return;
+    let existing = null;
+    try {
+        const { data } = await supabase
+            .from('committed_records')
+            .select('*')
+            .eq('id', id)
+            .maybeSingle();
+        existing = data || null;
+    } catch (err) {
+        console.error('Error fetching existing record', err);
+    }
+    renderDetail(record, existing);
+}
+
+function renderDetail(record, existing) {
+    formContainer.innerHTML = '';
+    const form = document.createElement('form');
+    form.className = 'approval-form';
+    const fields = Object.keys(record).filter(k => !['id','status','created_at'].includes(k));
+    fields.forEach(f => {
+        const group = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = f.replace(/_/g,' ');
+        group.appendChild(label);
+        if (existing) {
+            const curr = document.createElement('div');
+            curr.className = 'current-value';
+            curr.textContent = 'Current: ' + (existing[f] || '');
+            group.appendChild(curr);
+        }
+        const area = document.createElement('textarea');
+        area.name = f;
+        area.value = record[f] || '';
+        area.rows = 2;
+        area.addEventListener('input', (e)=>{ record[f] = e.target.value; updateDiff(area, existing ? existing[f] : null); });
+        group.appendChild(area);
+        if (existing && (existing[f] || '') !== (record[f] || '')) {
+            group.classList.add('changed');
+        }
+        form.appendChild(group);
+    });
+    const actions = document.createElement('div');
+    actions.className = 'action-buttons';
+    const approveBtn = document.createElement('button');
+    approveBtn.type = 'button';
+    approveBtn.textContent = 'Approve';
+    approveBtn.className = 'approve-btn';
+    approveBtn.addEventListener('click', () => approveRecord(record));
+    const rejectBtn = document.createElement('button');
+    rejectBtn.type = 'button';
+    rejectBtn.textContent = 'Reject';
+    rejectBtn.className = 'reject-btn';
+    rejectBtn.addEventListener('click', () => rejectRecord(record));
+    actions.appendChild(approveBtn);
+    actions.appendChild(rejectBtn);
+    form.appendChild(actions);
+    formContainer.appendChild(form);
+}
+
+function updateDiff(textarea, current) {
+    const group = textarea.parentElement;
+    if (current !== undefined && (current || '') !== textarea.value) {
+        group.classList.add('changed');
+    } else {
+        group.classList.remove('changed');
+    }
+}
+
+async function approveRecord(record) {
+    try {
+        await supabase.from('staging_entries').update({ status: 'approved' }).eq('id', record.id);
+        const upsertData = { ...record };
+        delete upsertData.status;
+        delete upsertData.created_at;
+        await supabase.from('committed_records').upsert(upsertData);
+        record.status = 'approved';
+        applyFilter();
+    } catch (err) {
+        console.error('Error approving record', err);
+        alert('Error approving record');
+    }
+}
+
+async function rejectRecord(record) {
+    try {
+        await supabase.from('staging_entries').update({ status: 'rejected' }).eq('id', record.id);
+        record.status = 'rejected';
+        applyFilter();
+    } catch (err) {
+        console.error('Error rejecting record', err);
+        alert('Error rejecting record');
+    }
+}
+
+statusFilter.addEventListener('change', applyFilter);
+window.addEventListener('DOMContentLoaded', loadRecords);


### PR DESCRIPTION
## Summary
- add `approvals.html` with two-pane layout
- implement new styling for admin approval view
- add `approvals.js` to load and process staging submissions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686374ba74c483298212ff6ae9a11abc