### PR TITLE
Improve approvals UI with sidebar and new filter

### DIFF
--- a/approvals.html
+++ b/approvals.html
@@ -15,22 +15,90 @@
         <img src="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/icons/person-circle.svg" class="user-icon" alt="User" />
         <span class="username">Admin-CPS</span>
     </nav>
-    <div class="approvals-wrapper">
-        <div class="approvals-list-pane">
-            <label for="status-filter" class="filter-label">Filter</label>
-            <select id="status-filter" multiple size="3">
-                <option value="pending" selected>Pending</option>
-                <option value="approved">Approved</option>
-                <option value="rejected">Rejected</option>
-            </select>
-            <ul id="submission-list" role="listbox" class="submission-list"></ul>
+    <div class="page-layout">
+        <div id="sidebar" class="sidebar expanded">
+            <div class="sidebar-top">
+                <img src="assets/logo.png" alt="Center for Policy Logo" class="logo" />
+                <span class="title">CPS Classification of Indian Knowledge</span>
+                <button class="toggle-btn" onclick="toggleSidebar()">«</button>
+            </div>
+
+            <br />
+            <br />
+
+            <div class="sidebar-middle">
+                <div>
+                    <p>
+                        This interactive visualizer allows you to explore the hierarchical classification of Indian
+                        Knowledge Systems. Each colored card represents a category, subcategory, or specific entry in
+                        the classification scheme.
+                    </p>
+                    <p>
+                        Click on a card to expand it and reveal more specific layers of knowledge. The deeper you go,
+                        the more granular the classification becomes — from broad areas like Vedas or Itihāsa, down to
+                        specific texts or concepts.
+                    </p>
+                </div>
+
+                <hr class="sidebar-divider">
+
+                <div class="sidebar-middle">
+                    <a href="https://bookish-archive-nexus.lovable.app/search" class="catalogue-link">Search The
+                        Catalogue</a>
+                </div>
+
+                <div class="sidebar-middle">
+                    <a href="https://bookish-archive-nexus.lovable.app" class="catalogue-link">Cataloguing Tool</a>
+                </div>
+            </div>
+
+            <div class="sidebar-footer">
+                <a href="https://github.com/rashwin88/CPSKnowledgeClassification" target="_blank" class="github-link">
+                    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v10/icons/github.svg" alt="GitHub"
+                        class="github-icon" />
+                    <span class="github-text">GitHub</span>
+                </a>
+
+
+                <a href="https://wa.me/?text=Explore%20this%20Classification%20of%20Indian%20Knowledge%20Systems:%20https%3A%2F%2Fcpsindia.org%2Fknowledge-classification"
+                    target="_blank" class="whatsapp-link">
+                    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v10/icons/whatsapp.svg" alt="WhatsApp"
+                        class="whatsapp-icon" />
+                    <span class="whatsapp-text">Share</span>
+                </a>
+
+                <a href="https://twitter.com/intent/tweet?text=Explore%20this%20Classification%20of%20Indian%20Knowledge%20Systems%20by%20Centre%20for%20Policy%20Studies%3A%20https%3A%2F%2Fcpsindia.org%2Fknowledge-classification"
+                    target="_blank" class="whatsapp-link">
+                    <img src="https://cdn.jsdelivr.net/npm/simple-icons@v10/icons/x.svg" alt="X"
+                        class="whatsapp-icon" />
+                    <span class="x-text">Share</span>
+                </a>
+            </div>
         </div>
-        <div class="approvals-detail-pane">
-            <div id="record-form" class="record-form"></div>
+
+        <div class="content-container">
+            <div class="approvals-wrapper">
+                <div class="approvals-list-pane">
+                    <label class="filter-label">Filter</label>
+                    <div class="multi-select">
+                        <button type="button" id="filter-button" class="dropdown-button">Status ▼</button>
+                        <div id="status-options" class="options hidden">
+                            <label><input type="checkbox" value="pending" checked> Pending</label>
+                            <label><input type="checkbox" value="approved" checked> Approved</label>
+                            <label><input type="checkbox" value="rejected" checked> Rejected</label>
+                        </div>
+                    </div>
+                    <ul id="submission-list" role="listbox" class="submission-list"></ul>
+                </div>
+                <div class="approvals-detail-pane">
+                    <div id="record-form" class="record-form"></div>
+                </div>
+            </div>
         </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
+    <script defer src="js/sidebar.js"></script>
     <script src="js/data.js"></script>
     <script src="js/approvals.js"></script>
 </body>

--- a/css/styles.css
+++ b/css/styles.css
@@ -1139,6 +1139,44 @@ body.dark-mode #settings-icon {
     margin-bottom: 8px;
 }
 
+.multi-select {
+    position: relative;
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+.multi-select .dropdown-button {
+    width: 100%;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    text-align: left;
+    cursor: pointer;
+}
+
+.multi-select .options {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    z-index: 100;
+    max-height: 200px;
+    overflow-y: auto;
+}
+
+.multi-select .options.hidden {
+    display: none;
+}
+
+.multi-select .options label {
+    display: block;
+    padding: 4px 8px;
+    font-size: 0.9em;
+}
+
 .submission-list {
     list-style: none;
     padding: 0;
@@ -1165,7 +1203,7 @@ body.dark-mode #settings-icon {
 }
 
 .approvals-list-item.selected {
-    background-color: #eef;
+    background-color: #ffd6d6;
 }
 
 .status-badge {
@@ -1196,10 +1234,20 @@ body.dark-mode #settings-icon {
     font-size: 0.75em;
     color: #555;
     margin-bottom: 2px;
+    background-color: #f5f5f5;
+    padding: 2px 4px;
+    border-radius: 4px;
+}
+
+.approval-form .changed {
+    border-left: 4px solid #f0ad4e;
+    background-color: #fff7e0;
+    padding-left: 4px;
 }
 
 .approval-form .changed textarea {
     border-color: #f0ad4e;
+    background-color: #fff;
 }
 
 .action-buttons {

--- a/js/approvals.js
+++ b/js/approvals.js
@@ -1,9 +1,16 @@
-const statusFilter = document.getElementById('status-filter');
+const filterButton = document.getElementById('filter-button');
+const filterMenu = document.getElementById('status-options');
+const statusChecks = document.querySelectorAll('#status-options input[type="checkbox"]');
 const listEl = document.getElementById('submission-list');
 const formContainer = document.getElementById('record-form');
 
 let stagingRecords = [];
 let selectedId = null;
+
+function toTitleCase(str) {
+    return str.replace(/_/g, ' ').replace(/\w\S*/g, (txt) =>
+        txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+}
 
 async function loadRecords() {
     try {
@@ -22,7 +29,9 @@ async function loadRecords() {
 }
 
 function applyFilter() {
-    const statuses = Array.from(statusFilter.selectedOptions).map(o => o.value);
+    const statuses = Array.from(statusChecks)
+        .filter(cb => cb.checked)
+        .map(cb => cb.value);
     const filtered = stagingRecords.filter(r => statuses.includes(r.status));
     renderList(filtered);
 }
@@ -79,7 +88,7 @@ function renderDetail(record, existing) {
     fields.forEach(f => {
         const group = document.createElement('div');
         const label = document.createElement('label');
-        label.textContent = f.replace(/_/g,' ');
+        label.textContent = toTitleCase(f);
         group.appendChild(label);
         if (existing) {
             const curr = document.createElement('div');
@@ -98,21 +107,23 @@ function renderDetail(record, existing) {
         }
         form.appendChild(group);
     });
-    const actions = document.createElement('div');
-    actions.className = 'action-buttons';
-    const approveBtn = document.createElement('button');
-    approveBtn.type = 'button';
-    approveBtn.textContent = 'Approve';
-    approveBtn.className = 'approve-btn';
-    approveBtn.addEventListener('click', () => approveRecord(record));
-    const rejectBtn = document.createElement('button');
-    rejectBtn.type = 'button';
-    rejectBtn.textContent = 'Reject';
-    rejectBtn.className = 'reject-btn';
-    rejectBtn.addEventListener('click', () => rejectRecord(record));
-    actions.appendChild(approveBtn);
-    actions.appendChild(rejectBtn);
-    form.appendChild(actions);
+    if (record.status === 'pending') {
+        const actions = document.createElement('div');
+        actions.className = 'action-buttons';
+        const approveBtn = document.createElement('button');
+        approveBtn.type = 'button';
+        approveBtn.textContent = 'Approve';
+        approveBtn.className = 'approve-btn';
+        approveBtn.addEventListener('click', () => approveRecord(record));
+        const rejectBtn = document.createElement('button');
+        rejectBtn.type = 'button';
+        rejectBtn.textContent = 'Reject';
+        rejectBtn.className = 'reject-btn';
+        rejectBtn.addEventListener('click', () => rejectRecord(record));
+        actions.appendChild(approveBtn);
+        actions.appendChild(rejectBtn);
+        form.appendChild(actions);
+    }
     formContainer.appendChild(form);
 }
 
@@ -151,5 +162,13 @@ async function rejectRecord(record) {
     }
 }
 
-statusFilter.addEventListener('change', applyFilter);
+statusChecks.forEach(cb => cb.addEventListener('change', applyFilter));
+filterButton.addEventListener('click', () => {
+    filterMenu.classList.toggle('hidden');
+});
+document.addEventListener('click', (e) => {
+    if (!filterMenu.contains(e.target) && e.target !== filterButton) {
+        filterMenu.classList.add('hidden');
+    }
+});
 window.addEventListener('DOMContentLoaded', loadRecords);


### PR DESCRIPTION
## Summary
- add sidebar layout and dropdown status filter on approvals page
- color pending item selection light red and show changed field diff styling
- hide action buttons for non-pending records and label fields in Title Case
- implement dropdown checkbox filter logic

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68637742e6fc8329af29d47303d8cd70