### PR TITLE
Fix approvals page layout

### DIFF
--- a/approvals.html
+++ b/approvals.html
@@ -76,7 +76,7 @@
             </div>
         </div>
 
-        <div class="content-container">
+        <div class="content-container approvals-container">
             <div class="approvals-wrapper">
                 <div class="approvals-list-pane">
                     <label class="filter-label">Filter</label>

--- a/css/styles.css
+++ b/css/styles.css
@@ -227,6 +227,21 @@ body {
     width: calc(100vw - 60px);
 }
 
+/* Approvals page specific container */
+.approvals-container {
+    margin-top: 60px;
+    margin-left: 182px;
+    width: calc(100vw - 182px);
+    display: flex;
+    justify-content: center;
+    box-sizing: border-box;
+}
+
+.sidebar.collapsed + .approvals-container {
+    margin-left: 60px;
+    width: calc(100vw - 60px);
+}
+
 
 .wrapper {
     display: flex;


### PR DESCRIPTION
## Summary
- prevent sidebar from overlapping approvals panel
- move approvals page content into a dedicated container

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686379a088d08329bf64df2a5f8b81a4