### PR TITLE
Add modal feedback to approval actions

### DIFF
--- a/approvals.html
+++ b/approvals.html
@@ -99,6 +99,13 @@
         </div>
     </div>
 
+    <div id="messageModal" class="modal-overlay hidden">
+        <div class="modal-content message-content">
+            <button type="button" class="modal-close" id="messageClose">&times;</button>
+            <p id="messageText"></p>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
     <script defer src="js/sidebar.js"></script>
     <script src="js/data.js"></script>

--- a/css/styles.css
+++ b/css/styles.css
@@ -842,6 +842,14 @@ body {
     box-shadow: 0 6px 24px rgba(0, 0, 0, 0.2);
 }
 
+/* Simple message modal */
+#messageModal .modal-content {
+    width: 300px;
+    max-width: 80vw;
+    height: auto;
+    text-align: center;
+}
+
 .book-details-grid {
     display: grid;
     grid-template-columns: 1fr 2fr;

--- a/js/approvals.js
+++ b/js/approvals.js
@@ -3,6 +3,25 @@ const filterMenu = document.getElementById('status-options');
 const statusChecks = document.querySelectorAll('#status-options input[type="checkbox"]');
 const listEl = document.getElementById('submission-list');
 const formContainer = document.getElementById('record-form');
+const messageModal = document.getElementById('messageModal');
+const messageText = document.getElementById('messageText');
+const messageClose = document.getElementById('messageClose');
+
+function showMessage(text) {
+    messageText.textContent = text;
+    messageModal.classList.remove('hidden');
+    requestAnimationFrame(() => messageModal.classList.add('active'));
+}
+
+function hideMessage() {
+    messageModal.classList.remove('active');
+    setTimeout(() => messageModal.classList.add('hidden'), 300);
+}
+
+messageClose.addEventListener('click', hideMessage);
+messageModal.addEventListener('click', (e) => {
+    if (e.target === messageModal) hideMessage();
+});
 
 let stagingRecords = [];
 let selectedId = null;
@@ -145,9 +164,10 @@ async function approveRecord(record) {
         await supabase.from('committed_records').upsert(upsertData);
         record.status = 'approved';
         applyFilter();
+        showMessage('Record approved successfully');
     } catch (err) {
         console.error('Error approving record', err);
-        alert('Error approving record');
+        showMessage('Error approving record');
     }
 }
 
@@ -156,9 +176,10 @@ async function rejectRecord(record) {
         await supabase.from('staging_entries').update({ status: 'rejected' }).eq('id', record.id);
         record.status = 'rejected';
         applyFilter();
+        showMessage('Record rejected successfully');
     } catch (err) {
         console.error('Error rejecting record', err);
-        alert('Error rejecting record');
+        showMessage('Error rejecting record');
     }
 }
 


### PR DESCRIPTION
## Summary
- show approval action messages in a new modal
- style message modal
- include modal markup in approvals page

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6863845fff0c8329a0af02e56407869b