### PR TITLE
Fix sidebar and menubar layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,7 +8,7 @@ body {
 }
 
 .topbar {
-    width: calc(100% - 182px);
+    width: 100%;
     background-color: #D3D3D3;
     color: #000000;
     padding: 8px 16px;
@@ -19,7 +19,7 @@ body {
     box-sizing: border-box;
     position: fixed;
     top: 0;
-    left: 182px;
+    left: 0;
     z-index: 1000;
 }
 
@@ -288,13 +288,13 @@ body {
     text-align: left;
     transition: width 0.3s ease;
     position: fixed;
-    top: 60px;
+    top: 0;
     left: 0;
     bottom: 0;
     font-size: 14px;
-    z-index: 900;
+    z-index: 1100;
     overflow-y: auto;
-    height: calc(100vh - 60px);
+    height: 100vh;
 }
 
 

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -3,11 +3,6 @@ function updateLayout() {
     const collapsed = sidebar.classList.contains('collapsed');
     const left = collapsed ? '60px' : '182px';
 
-    const topbar = document.querySelector('.topbar');
-    if (topbar) {
-        topbar.style.left = left;
-        topbar.style.width = `calc(100% - ${left})`;
-    }
 
     document.querySelectorAll('.content-container, .approvals-container')
         .forEach(el => {


### PR DESCRIPTION
## Summary
- make the topbar span the full width of the page
- ensure the sidebar covers the full height and sits above the topbar
- stop JS from shifting the topbar when toggling the sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867643753a883298d729268fce19998