### PR TITLE
Fix approvals container offset

### DIFF
--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -3,11 +3,15 @@ function updateLayout() {
     const collapsed = sidebar.classList.contains('collapsed');
     const left = collapsed ? '60px' : '182px';
 
+    const topbar = document.querySelector('.topbar');
+    const topHeight = topbar ? `${topbar.offsetHeight}px` : '0px';
 
     document.querySelectorAll('.content-container, .approvals-container')
         .forEach(el => {
             el.style.marginLeft = left;
             el.style.width = `calc(100% - ${left})`;
+            el.style.marginTop = topHeight;
+            el.style.height = `calc(100vh - ${topHeight})`;
         });
 }
 


### PR DESCRIPTION
## Summary
- ensure left/right approvals panes start directly under the menubar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68676812b7b8832998836dc2e6b28911