### PR TITLE
Display node tags on a new line

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -173,6 +173,7 @@ body {
     overflow-wrap: anywhere;
     word-break: break-word;
     hyphens: auto;
+    white-space: pre-line;
 }
 
 .card .count {
@@ -612,6 +613,7 @@ body {
     overflow-wrap: anywhere;
     word-break: break-word;
     hyphens: auto;
+    white-space: pre-line;
 }
 
 .card-right {
@@ -1066,7 +1068,7 @@ body.no-hyphenation .card-subtitle {
     overflow-wrap: normal;
     word-break: normal;
     hyphens: none;
-    white-space: normal;
+    white-space: pre-line;
 }
 
 .setting-item {

--- a/js/main.js
+++ b/js/main.js
@@ -338,7 +338,7 @@ function createCard(data, row) {
     card.setAttribute('data-node-type', nodeType);
     let labelText = data.node_label || '';
     if (Array.isArray(data.node_tags) && data.node_tags.length > 0) {
-        labelText = `${labelText} ${data.node_tags[0]}`.trim();
+        labelText = `${labelText}\n${data.node_tags[0]}`.trim();
     }
     card.setAttribute('data-label-original', labelText);
     const bookCount = 0;
@@ -525,7 +525,7 @@ function createLeafCard(data, row) {
     card.setAttribute('data-node-type', leafType);
     let labelText = data.node_label || '';
     if (Array.isArray(data.node_tags) && data.node_tags.length > 0) {
-        labelText = `${labelText} ${data.node_tags[0]}`.trim();
+        labelText = `${labelText}\n${data.node_tags[0]}`.trim();
     }
     card.setAttribute('data-label-original', labelText);
     const bookCount = 0;


### PR DESCRIPTION
## Summary
- render `node_tags[0]` on its own line
- allow line breaks in card labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a1cb4efc8329829c297bc3e4328a