### PR TITLE
Adjust barren container width and hide empty rows

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -552,10 +552,25 @@ body {
     grid-template-columns: repeat(auto-fill, minmax(114px, 1fr));
     gap: 4px;
     padding: 8px;
-    background-color: #ddd;
-    max-width: 1200px;
-    min-width: 800px;
+    background-color: transparent;
+    max-width: 1080px;
+    min-width: 720px;
+    width: 90%;
     margin: 0 auto;
+}
+
+#barren-row,
+#leaf-row {
+    display: none;
+}
+
+#second-row,
+#third-row,
+#fourth-row,
+#fifth-row,
+#sixth-row,
+#seventh-row {
+    display: none;
 }
 
 .horizontal-card {

--- a/js/main.js
+++ b/js/main.js
@@ -590,6 +590,11 @@ function renderFirstRow(dataList) {
 function renderSecondRow(childData) {
     // Clear previous
     secondRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        secondRow.style.display = 'none';
+        return;
+    }
+    secondRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'second-row');
         secondRow.appendChild(card);
@@ -599,6 +604,11 @@ function renderSecondRow(childData) {
 function renderThirdRow(childData) {
     // Clear previous
     thirdRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        thirdRow.style.display = 'none';
+        return;
+    }
+    thirdRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'third-row');
         thirdRow.appendChild(card);
@@ -608,6 +618,11 @@ function renderThirdRow(childData) {
 function renderFourthRow(childData) {
     // Clear previous
     fourthRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        fourthRow.style.display = 'none';
+        return;
+    }
+    fourthRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'fourth-row');
         fourthRow.appendChild(card);
@@ -617,6 +632,11 @@ function renderFourthRow(childData) {
 function renderFifthRow(childData) {
     // Clear previous
     fifthRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        fifthRow.style.display = 'none';
+        return;
+    }
+    fifthRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'fifth-row');
         fifthRow.appendChild(card);
@@ -626,6 +646,11 @@ function renderFifthRow(childData) {
 function renderSixthRow(childData) {
     // Clear previous
     sixthRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        sixthRow.style.display = 'none';
+        return;
+    }
+    sixthRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'sixth-row');
         sixthRow.appendChild(card);
@@ -635,6 +660,11 @@ function renderSixthRow(childData) {
 function renderSeventhRow(childData) {
     // Clear previous
     seventhRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        seventhRow.style.display = 'none';
+        return;
+    }
+    seventhRow.style.display = 'flex';
     childData.forEach(data => {
         const card = createCard(data, 'seventh-row');
         seventhRow.appendChild(card);
@@ -643,6 +673,11 @@ function renderSeventhRow(childData) {
 
 function renderBarrenRow(childData) {
     barrenRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        barrenRow.style.display = 'none';
+        return;
+    }
+    barrenRow.style.display = 'grid';
     childData.forEach(data => {
         const card = createCard(data, 'barren-row');
         barrenRow.appendChild(card);
@@ -652,6 +687,11 @@ function renderBarrenRow(childData) {
 
 function renderLeafRow(childData) {
     leafRow.innerHTML = '';
+    if (!childData || childData.length === 0) {
+        leafRow.style.display = 'none';
+        return;
+    }
+    leafRow.style.display = 'grid';
     childData.forEach(data => {
         const card = createLeafCard(data, 'leaf-row');
         leafRow.appendChild(card);


### PR DESCRIPTION
## Summary
- reduce barren row width and remove background color
- hide barren row and leaf row containers when empty
- hide secondary row containers by default and show on data
- stop displaying deeper rows when no child cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868a8a14d80832998c569e6e5adeb7f