### PR TITLE
Update modal styling and treat pages as text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -827,7 +827,7 @@ body {
     background: #ffffff;
     padding: 20px 20px 16px 20px;
     border-radius: 10px;
-    width: 600px;
+    width: 720px;
     height: 600px;
     max-width: 90vw;
     max-height: 90vh;
@@ -856,7 +856,7 @@ body {
 
 /* Book modal specific styling */
 #bookModal .modal-content {
-    max-width: 600px;
+    max-width: 720px;
     width: 90%;
     max-height: 80vh;
     overflow-y: auto;
@@ -910,6 +910,7 @@ body {
 .react-form {
     display: flex;
     flex-direction: column;
+    gap: 12px;
     flex: 1;
     font-family: "Literata", Arial, Helvetica, sans-serif;
     height: 100%;
@@ -952,7 +953,7 @@ body {
 
 .react-form textarea {
     resize: vertical;
-    min-height: 4.5em;
+    min-height: 3em;
 }
 
 .react-form .form-actions {

--- a/js/reactForm.js
+++ b/js/reactForm.js
@@ -44,7 +44,11 @@
         useEffect(() => {
             if (initialData) {
                 // Editing existing book
-                setFormData({ ...emptyFormState, ...initialData });
+                const data = { ...emptyFormState, ...initialData };
+                if (data.pages !== undefined && data.pages !== null) {
+                    data.pages = String(data.pages);
+                }
+                setFormData(data);
             } else {
                 // Fresh form for new entry
                 setFormData({ ...emptyFormState });
@@ -100,7 +104,7 @@
                 edition: formData.edition || null,
                 publisher: formData.publisher || null,
                 year_of_publication: formData.year_of_publication ? parseInt(formData.year_of_publication, 10) : null,
-                pages: formData.pages || null,
+                pages: formData.pages ? String(formData.pages) : null,
                 volume: formData.volume || null,
                 language: formData.language || null,
                 language_note: formData.language_note || null,


### PR DESCRIPTION
## Summary
- widen modal windows by 20%
- align modal form styling with approvals panel
- ensure `pages` values are handled as strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ae27054c8329ae13f3dd314c2d90