### PR TITLE
Apply approval form style to home modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -310,6 +310,10 @@ body {
     gap: 10px;
 }
 
+.sidebar .title {
+    font-weight: bold;
+}
+
 .sidebar.collapsed .sidebar-top {
     gap: 4px;
 }

--- a/js/reactForm.js
+++ b/js/reactForm.js
@@ -132,7 +132,7 @@
             setSubmitting(false);
         };
 
-        return React.createElement('form', { className: 'react-form', onSubmit: handleSubmit }, [
+        return React.createElement('form', { className: 'react-form approval-form', onSubmit: handleSubmit }, [
             React.createElement('div', { className: 'form-fields' }, [
                 FormField({ label: 'Classification Number', name: 'classification_number', value: classificationNumber, onChange: () => {}, readOnly: true }),
                 FormField({ label: 'Item Number', name: 'item_number', value: formData.item_number, onChange: handleChange, required: true }),


### PR DESCRIPTION
## Summary
- bold sidebar title
- use `approval-form` styling for the React form used in home page modals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868b0ce1bec83298edec6edf6283b32