### PR TITLE
Add edit modal for classification cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -796,11 +796,36 @@ body {
     font-size: 14px;
 }
 
+.edit-icon {
+    position: absolute;
+    bottom: 4px;
+    left: 4px;
+    width: 18px;
+    height: 18px;
+    border: 1px solid #333;
+    border-radius: 50%;
+    background: #fff;
+    color: #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-weight: bold;
+    font-size: 14px;
+}
+
 .horizontal-card .add-icon {
     position: static;
     bottom: auto;
     right: auto;
     margin-left: 4px;
+}
+
+.horizontal-card .edit-icon {
+    position: static;
+    bottom: auto;
+    left: auto;
+    margin-right: 4px;
 }
 
 .modal-overlay {
@@ -978,6 +1003,31 @@ body {
 
 .react-form button:disabled {
     background-color: #777;
+}
+
+.edit-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.edit-form .form-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.edit-form input,
+.edit-form textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 0.9em;
+    box-sizing: border-box;
+}
+
+.edit-form .form-actions {
+    text-align: right;
 }
 
 #reactFormRoot {

--- a/index.html
+++ b/index.html
@@ -153,6 +153,25 @@
         </div>
     </div>
 
+    <div id="editModal" class="modal-overlay hidden">
+        <div class="modal-content">
+            <button type="button" class="modal-close" id="editModalClose">&times;</button>
+            <form id="editForm" class="edit-form">
+                <div class="form-group">
+                    <label for="editLabel">Label</label>
+                    <input type="text" id="editLabel" />
+                </div>
+                <div class="form-group">
+                    <label for="editTags">Node Tags (JSON)</label>
+                    <textarea id="editTags" rows="4"></textarea>
+                </div>
+                <div class="form-actions">
+                    <button type="submit" id="editSave">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
 
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.39.5/dist/umd/supabase.min.js"></script>
     <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>


### PR DESCRIPTION
## Summary
- add modal for editing node label and node tags
- support opening the modal from new pencil icon on each card
- update node record in supabase when saved
- style new edit modal and icon

## Testing
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6875c0baf4e48329a9f7fbeccf45393e