### PR TITLE
Fix editing modal fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                     <input type="text" id="editLabel" />
                 </div>
                 <div class="form-group">
-                    <label for="editTags">Node Tags (JSON)</label>
+                    <label for="editTags">Metadata</label>
                     <textarea id="editTags" rows="4"></textarea>
                 </div>
                 <div class="form-actions">


### PR DESCRIPTION
## Summary
- show metadata as text in edit modal
- display label using `node_label` and metadata from `node_tags`
- save updated label and metadata back to Supabase

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875c397aaa08329825da7e201a081e0